### PR TITLE
refactor: Render images from public file (jpg thumbnails) instead of …

### DIFF
--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -3,14 +3,12 @@ import buyMarketplaceItem from "../helpers/buyMarketplaceItem";
 
 export default function Modal({ handleHideModal, nft}) {
 
-  console.log("MODAL NFT:", nft)
-
   return (
     <>
       <div className="fixed inset-0 h-full z-40 flex justify-center items-center">
         <div className="card w-96 bg-base-100 shadow-xl image-full">
           <figure>
-            <img src={nft.image} alt={nft.name} />
+            <img src={`./images/thumbnails/${nft.name}.jpg`} alt={nft.name} />
           </figure>
           <div className="card-body flex flex-col justify-between">
             <h2 className="card-title">{nft.name}</h2>

--- a/frontend/src/views/UserCollection.jsx
+++ b/frontend/src/views/UserCollection.jsx
@@ -40,7 +40,7 @@ export default function UserCollection() {
               purchases.current.map((item, idx) => (
                 <div key={idx} className="card card-compact bg-base-100 shadow-xl m-5 w-72">
                   <figure>
-                    <img src={item.image} alt={item.name} />
+                    <img src={`./images/thumbnails/${item.name}.jpg`} alt={item.name} />
                   </figure>
                   <div className="card-body">
                     <h2 className="card-title">{item.name}</h2>


### PR DESCRIPTION
# Description

- Images in Modal and UserCollection components now calling image from local (public) file instead of making call to IPFS, dramatically improves rendering time (previously unacceptably slow)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
